### PR TITLE
Rails 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ has-bit-field
 
 has-bit-field allows you to use one attribute of an object to store a bit field which stores the boolean state for multiple flags.
 
+**Rails 3.0.x**
+
+Add the gem to your Gemfile. 
+
+    gem 'has-bit-field'
+
+**Rails 2.3.x**
+
 To use this with Active Record, you would first require this gem in `config/environment.rb`:
 
     config.gem "has-bit-field"

--- a/lib/has-bit-field.rb
+++ b/lib/has-bit-field.rb
@@ -34,19 +34,21 @@ module HasBitField
           #{field} != #{field}_was
         end
       }
-      if(respond_to?(:named_scope))
-        if columns_hash[bit_field_attribute.to_s].null
-          class_eval %{
-            named_scope :#{field}, :conditions => ["#{table_name}.#{bit_field_attribute} IS NOT NULL AND (#{table_name}.#{bit_field_attribute} & ?) != 0", #{field}_bit]
-            named_scope :not_#{field}, :conditions => ["#{table_name}.#{bit_field_attribute} IS NULL OR (#{table_name}.#{bit_field_attribute} & ?) = 0", #{field}_bit]          
-          }
-        else
-          class_eval %{
-            named_scope :#{field}, :conditions => ["(#{table_name}.#{bit_field_attribute} & ?) != 0", #{field}_bit]
-            named_scope :not_#{field}, :conditions => ["(#{table_name}.#{bit_field_attribute} & ?) = 0", #{field}_bit]
-          }
-        end
+
+      scope_sym = respond_to?(:validates) ? :scope : :named_scope
+
+      if columns_hash[bit_field_attribute.to_s].null
+        class_eval %{
+          send scope_sym, :#{field}, :conditions => ["#{table_name}.#{bit_field_attribute} IS NOT NULL AND (#{table_name}.#{bit_field_attribute} & ?) != 0", #{field}_bit]
+          send scope_sym, :not_#{field}, :conditions => ["#{table_name}.#{bit_field_attribute} IS NULL OR (#{table_name}.#{bit_field_attribute} & ?) = 0", #{field}_bit]          
+        }
+      else
+        class_eval %{
+          send scope_sym, :#{field}, :conditions => ["(#{table_name}.#{bit_field_attribute} & ?) != 0", #{field}_bit]
+          send scope_sym, :not_#{field}, :conditions => ["(#{table_name}.#{bit_field_attribute} & ?) = 0", #{field}_bit]
+        }
       end
+
     end
   end
 end

--- a/test/has-bit-field_test.rb
+++ b/test/has-bit-field_test.rb
@@ -178,7 +178,7 @@ class HasBitFieldTest < Test::Unit::TestCase
     s.chops_trees = true
     assert s.chops_trees?
     assert s.valid?
-    assert !s.errors[:chops_trees]
+    assert s.errors[:chops_trees].blank?
     assert s.save
   end
 
@@ -202,7 +202,7 @@ class HasBitFieldTest < Test::Unit::TestCase
     s.plays_piano = true
     assert s.plays_piano?
     assert s.valid?
-    assert !s.errors[:plays_piano]
+    assert s.errors[:plays_piano].blank?
     assert s.save
   end
 


### PR DESCRIPTION
Hi Paul,

I am using has-bit-field in a rails 3 project, and had to make some changes.
1. Since 'named_scope' method is deprecated in rails 3, I have modified the gem sources to use 'scope' method in rails 3, also 'named_scope' method is retained for rails 2 compatibility.
2. I have also modified the tests so they pass in both rails 2 and 3.
3. README.md is modified to mention usage notes for rails 3.
4. I was not sure of the changes in required in gemspec for adding both rails 2 and 3 development dependencies. So it's kept intact.

Please review the changes and let me know if you want any changes. Also please advice on the point 4.

Thanks,
Girish
