### PR TITLE
Avoid crashing in the has_bit_field class method when column does not exist

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm ree@has-bit-field --create
+rvm ruby-1.9.3@has-bit-field --create

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,15 +6,28 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activerecord (2.3.10)
-      activesupport (= 2.3.10)
-    activesupport (2.3.10)
-    sqlite3-ruby (1.3.2)
+    activemodel (3.2.11)
+      activesupport (= 3.2.11)
+      builder (~> 3.0.0)
+    activerecord (3.2.11)
+      activemodel (= 3.2.11)
+      activesupport (= 3.2.11)
+      arel (~> 3.0.2)
+      tzinfo (~> 0.3.29)
+    activesupport (3.2.11)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
+    arel (3.0.2)
+    builder (3.0.4)
+    i18n (0.6.1)
+    multi_json (1.5.0)
+    sqlite3 (1.3.7)
+    tzinfo (0.3.35)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 2.3.5)
+  activerecord (~> 3.0)
   has-bit-field!
-  sqlite3-ruby
+  sqlite3

--- a/has-bit-field.gemspec
+++ b/has-bit-field.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.description = "Provides an easy way to work with bit fields in active record"
 
   s.rubyforge_project = "has-bit-field"
-  s.add_development_dependency "sqlite3-ruby"
-  s.add_development_dependency "activerecord", "~> 2.3.5"
+  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "activerecord", "~> 3.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/has-bit-field.rb
+++ b/lib/has-bit-field.rb
@@ -4,6 +4,10 @@ module HasBitField
   # all following arguments should also be symbols,
   # which will be the name of each flag in the bit field
   def has_bit_field(bit_field_attribute, *args)
+    if columns_hash[bit_field_attribute.to_s].blank?
+      Rails.logger.error("[has_bit_field] column undefined #{bit_field_attribute}") if defined?(Rails) && Rails.respond_to?(:logger)
+      return
+    end
     args.each_with_index do |field,i|
       class_eval %{
         class << self

--- a/test/has-bit-field_test.rb
+++ b/test/has-bit-field_test.rb
@@ -206,4 +206,12 @@ class HasBitFieldTest < Test::Unit::TestCase
     assert s.save
   end
 
+  def test_environment_will_not_die_on_undefined_fields
+    assert_nothing_raised do
+      Person.class_eval do
+        has_bit_field :not_a_happy_field, :if_only_it_existed, :but_its_not_in_the_db, :we_had_hoped_for_it_but_its_not_there, :silence
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Add support to avoid crashing when loading a rails environment before the column is defined in the database.  For applications that might load models during a migration this will save their migration from failing before it has a chance to create the necessary columns for the has_bit_field to work.  

Also includes some updates to support running in ruby1.9.3 for rails 3.x apps (running the local test suite)
