### PR TITLE
Don't blow up if the table hasn't been created yet

### DIFF
--- a/lib/has-bit-field.rb
+++ b/lib/has-bit-field.rb
@@ -4,6 +4,10 @@ module HasBitField
   # all following arguments should also be symbols,
   # which will be the name of each flag in the bit field
   def has_bit_field(bit_field_attribute, *args)
+    unless table_exists?
+      Rails.logger.error("[has_bit_field] table undefined #{table_name}") if defined?(Rails) && Rails.respond_to?(:logger)
+      return
+    end
     if columns_hash[bit_field_attribute.to_s].blank?
       Rails.logger.error("[has_bit_field] column undefined #{bit_field_attribute}") if defined?(Rails) && Rails.respond_to?(:logger)
       return


### PR DESCRIPTION
We had an issue where due to an Observer, a class with has_bit_field was getting loaded during db:create / db:migrate and its table hadn't been created yet.
