### PR TITLE
add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+cache: bundler
+sudo: false
+matrix:
+  fast_finish: true
+branches:
+  only: master
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.0
+  - 2.3.0
+  - 2.4.0
+script: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# has-bit-field
+# has-bit-field [![Build Status](https://travis-ci.org/pjb3/has-bit-field.svg?branch=master)](https://travis-ci.org/pjb3/has-bit-field)
 
 has-bit-field allows you to use one attribute of an object to store a bit field which stores the boolean state for multiple flags. Requires Rails 3.0 or greater.
 


### PR DESCRIPTION
Here's the build results https://travis-ci.org/szTheory/has-bit-field/jobs/364171409. You can see it's passing for
  - 1.9.3
  - 2.0.0
  - 2.1.0

and failing for
  - 2.2.0
  - 2.3.0
  - 2.4.0

I think this is related due to the old version of minitest. 2.2.0 and up only support a new version of minitest which isn't backwards compatible and might (?) break 1.9.3 support.